### PR TITLE
fix(editor): apply font size setting to all editors

### DIFF
--- a/client/src/components/CodeViewer.tsx
+++ b/client/src/components/CodeViewer.tsx
@@ -6,17 +6,26 @@ const PADDING_TOP = 12;
 const PADDING_BOTTOM = 12;
 const PADDING = PADDING_TOP + PADDING_BOTTOM;
 
-const baseOptions = {
-  minimap: { enabled: false },
-  fontSize: 13,
-  lineHeight: LINE_HEIGHT,
-  scrollBeyondLastLine: false,
-  padding: { top: PADDING_TOP, bottom: PADDING_BOTTOM },
-  renderLineHighlight: "none" as const,
-  overviewRulerLanes: 0,
-  hideCursorInOverviewRuler: true,
-  scrollbar: { vertical: "hidden" as const, horizontal: "auto" as const },
-};
+const FONT_SIZE_KEY = "devflow_editor_font_size";
+const DEFAULT_FONT_SIZE = 14;
+
+export function getEditorFontSize() {
+  return parseInt(localStorage.getItem(FONT_SIZE_KEY) || String(DEFAULT_FONT_SIZE));
+}
+
+function baseOptions() {
+  return {
+    minimap: { enabled: false },
+    fontSize: getEditorFontSize(),
+    lineHeight: LINE_HEIGHT,
+    scrollBeyondLastLine: false,
+    padding: { top: PADDING_TOP, bottom: PADDING_BOTTOM },
+    renderLineHighlight: "none" as const,
+    overviewRulerLanes: 0,
+    hideCursorInOverviewRuler: true,
+    scrollbar: { vertical: "hidden" as const, horizontal: "auto" as const },
+  };
+}
 
 export function editorHeight(code: string, minLines = 1) {
   return Math.max(code.split("\n").length, minLines) * LINE_HEIGHT + PADDING;
@@ -129,7 +138,7 @@ export default function CodeViewer({ code, language, onCite, lineComments, edito
           language={language}
           theme="vs-dark"
           value={code}
-          options={{ ...baseOptions, readOnly: true, glyphMargin: !!hasComments }}
+          options={{ ...baseOptions(), readOnly: true, glyphMargin: !!hasComments }}
           onMount={handleMount}
         />
       </div>
@@ -174,4 +183,4 @@ export default function CodeViewer({ code, language, onCite, lineComments, edito
   );
 }
 
-export { baseOptions };
+export { baseOptions, FONT_SIZE_KEY };

--- a/client/src/components/SnapshotPanel.tsx
+++ b/client/src/components/SnapshotPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { DiffEditor } from "@monaco-editor/react";
 import type { Snapshot } from "../services/api";
 import { timeAgo } from "../lib/timeAgo";
+import { getEditorFontSize } from "./CodeViewer";
 import Button from "./Button";
 
 interface Props {
@@ -85,7 +86,7 @@ export default function SnapshotPanel({ snapshots, currentCode, currentLanguage,
                       options={{
                         readOnly: true,
                         minimap: { enabled: false },
-                        fontSize: 13,
+                        fontSize: getEditorFontSize(),
                         lineHeight: 20,
                         scrollBeyondLastLine: false,
                         renderSideBySide: false,

--- a/client/src/components/SnippetForm.tsx
+++ b/client/src/components/SnippetForm.tsx
@@ -165,7 +165,7 @@ export default function SnippetForm({ initial, onSubmit, onSave, submitLabel }: 
           value={code}
           onChange={(v) => setCode(v ?? "")}
           onMount={handleMount}
-          options={baseOptions}
+          options={baseOptions()}
         />
       </div>
 

--- a/client/src/pages/LivePage.tsx
+++ b/client/src/pages/LivePage.tsx
@@ -164,7 +164,7 @@ export default function LivePage() {
             language={snippet.language}
             theme="vs-dark"
             onMount={handleMount}
-            options={{ ...baseOptions, readOnly, scrollbar: { vertical: "auto", horizontal: "auto" } }}
+            options={{ ...baseOptions(), readOnly, scrollbar: { vertical: "auto", horizontal: "auto" } }}
           />
         </div>
       )}

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -7,8 +7,7 @@ import { stripeRedirect } from "../lib/user";
 import useAction from "../hooks/useAction";
 import Button from "../components/Button";
 import { inputClass } from "../components/AuthLayout";
-
-const FONT_SIZE_KEY = "devflow_editor_font_size";
+import { FONT_SIZE_KEY } from "../components/CodeViewer";
 
 type TotpStep = "idle" | "setup";
 


### PR DESCRIPTION
## Summary

The editor font size setting in Settings saved to localStorage but was never read by any editor — they all hardcoded `fontSize: 13`. Converted `baseOptions` to a function that reads from localStorage on each call, and updated all four editor consumers (CodeViewer, SnippetForm, LivePage, SnapshotPanel). Also aligned the default to 14px to match the settings UI.